### PR TITLE
hide server sensetive information

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -11,3 +11,11 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 DB_HOST=database
 DB_PORT=5432
+
+# sensetive server information
+
+EMAIL_HOST = test_host.gm.com
+EMAIL_PORT = 28283 
+EMAIL_HOST_USER = "dz_test_email_host_user@gmail.com"
+DEFAULT_FROM_EMAIL = "dz_test_def_from_email@gmail.com"
+EMAIL_HOST_PASSWORD = "dz_test_password"

--- a/config/settings.py
+++ b/config/settings.py
@@ -113,11 +113,11 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = "smtp.gmail.com"
-EMAIL_PORT = 465
-EMAIL_HOST_USER = "dizi.izi.plan@gmail.com"
-DEFAULT_FROM_EMAIL = "dizi.izi.plan@gmail.com"
-EMAIL_HOST_PASSWORD = "tkttxsrnycqeijpw"
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = os.getenv("EMAIL_PORT")
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 EMAIL_USE_TLS = False
 EMAIL_USE_SSL = True
 


### PR DESCRIPTION
Спрятаны в .env EMAIL_HOST, EMAIL_PORT, EMAIL_HOST_USER, DEFAULT_FROM_EMAIL, EMAIL_HOST_PASSWORD
вместо настоящих подставлены "шаблонные" данные.