### PR TITLE
Work in progress: proposed task queue implementation

### DIFF
--- a/layout_generator/queue/consumer/main.py
+++ b/layout_generator/queue/consumer/main.py
@@ -1,0 +1,59 @@
+import asyncio
+import json
+
+from nats.aio.client import Client as NATS
+
+from layout_generator.queue.literals import NATS_STREAM_NAME, NATS_SUBJECT_LAYOUT_TASKS
+from layout_generator.types import GenerateLayoutRequest
+
+DURABLE_NAME = "vile_vincenzo"
+
+
+async def mock_handler(msg):
+    try:
+        data = json.loads(msg.data.decode())
+        print(f"Received task: {data}")
+        
+
+        # Validate message schema
+        _ = GenerateLayoutRequest(**data)
+
+        # Simulate processing
+        # Algorithm goes here ->
+        await asyncio.sleep(1)
+
+        # Store results in jetstream
+
+        print(f"Processed task: {data}")
+
+    except Exception as e:
+        print(f"Failed to process message: {e}")
+
+    await msg.ack()
+
+
+async def main():
+    nc = NATS()
+    await nc.connect()
+
+    js = nc.jetstream()
+
+    # Ensure the stream exists — optional if already created by producer
+    # Not sure if calling this on existing stream will throw an exception
+    await js.add_stream(name=NATS_STREAM_NAME, subjects=[NATS_SUBJECT_LAYOUT_TASKS])
+
+    await js.subscribe(
+        subject=NATS_SUBJECT_LAYOUT_TASKS,
+        durable=DURABLE_NAME,
+        stream=NATS_STREAM_NAME,
+        cb=mock_handler,
+        manual_ack=True
+    )
+
+    print(f"worker durable_name={DURABLE_NAME} listening on {NATS_SUBJECT_LAYOUT_TASKS} subject")
+    while True:
+        await asyncio.sleep(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/layout_generator/queue/literals.py
+++ b/layout_generator/queue/literals.py
@@ -1,0 +1,5 @@
+NATS_STREAM_NAME = "layouts"
+NATS_SUBJECT_LAYOUT_TASKS = "layouts.tasks"
+NATS_SUBJECT_LAYOUT_RESULTS = "layouts.results"
+
+ENV_KEY_NATS_URL = "NATS_URL"

--- a/layout_generator/queue/producer/interface.py
+++ b/layout_generator/queue/producer/interface.py
@@ -1,0 +1,17 @@
+"""
+Defines a TaskQueue interface that is consumed
+on producer side.
+"""
+
+from typing import Protocol
+
+from layout_generator.types import GenerateLayoutRequest, GenerateLayoutResult, TaskStatus
+
+
+class TaskQueue(Protocol):
+    @classmethod
+    def get_instance(cls) -> "TaskQueue": ...
+
+    def enqueue_task(self, payload: GenerateLayoutRequest) -> str: ...
+    def get_task_status(self, task_id: str) -> TaskStatus | None: ...
+    def get_task_results(self, task_id: str) -> GenerateLayoutResult | None: ...

--- a/layout_generator/queue/producer/interface.py
+++ b/layout_generator/queue/producer/interface.py
@@ -5,6 +5,7 @@ on producer side.
 
 from typing import Protocol
 
+from layout_generator.queue.producer.nats_producer import NATSProducer
 from layout_generator.types import GenerateLayoutRequest, GenerateLayoutResult, TaskStatus
 
 
@@ -15,3 +16,7 @@ class TaskQueue(Protocol):
     def enqueue_task(self, payload: GenerateLayoutRequest) -> str: ...
     def get_task_status(self, task_id: str) -> TaskStatus | None: ...
     def get_task_results(self, task_id: str) -> GenerateLayoutResult | None: ...
+
+
+def get_task_queue() -> TaskQueue:
+    return NATSProducer.get_instance() # For now do this instead of a proper dependency injection.

--- a/layout_generator/queue/producer/nats_producer.py
+++ b/layout_generator/queue/producer/nats_producer.py
@@ -1,0 +1,121 @@
+import asyncio
+import atexit
+import os
+import threading
+import uuid
+from threading import Lock
+
+from nats.aio.client import Client as NATS
+from nats.js.api import StreamConfig
+
+from layout_generator.queue.literals import ENV_KEY_NATS_URL, NATS_STREAM_NAME, NATS_SUBJECT_LAYOUT_TASKS
+from layout_generator.types import GenerateLayoutRequest, GenerateLayoutResult, TaskStatus
+
+
+class NATSProducer:
+    """
+    Implements TaskQueue interface.
+    """
+    @classmethod
+    def get_instance(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = NATSProducer()
+            return cls._instance
+        
+    def enqueue_task(self, payload: GenerateLayoutRequest) -> str:
+        task_id = str(uuid.uuid4())
+
+        coro = self._publish(
+            subject=NATS_SUBJECT_LAYOUT_TASKS, 
+            message=self._to_message(payload),
+            headers={
+                "task_id": task_id
+            }
+        )
+        asyncio.run_coroutine_threadsafe(
+            coro, 
+            self._loop,
+        )
+
+        return task_id
+    
+    def get_task_status(self, task_id: str) -> TaskStatus | None:
+        return "PENDING"  # TODO: implement with jetstream
+    
+    def get_task_results(self, task_id: str) -> GenerateLayoutResult | None:
+        pass # TODO: implement with jetstream
+
+
+    """
+    
+    ---------- PRIVATE METHODS AND FIELDS ----------
+    
+    """
+
+    _instance = None
+    _lock = Lock()
+
+    def __init__(self):
+        """
+        Starts a background event loop to run async methods, 
+        opens a new NATS connections,
+        registers a shutdown callback on interpreter exit.
+        """
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+        nats_url = os.environ.get(ENV_KEY_NATS_URL)
+        if nats_url is None:
+            raise Exception(f"{ENV_KEY_NATS_URL} variable not found in env")
+        
+        fut = asyncio.run_coroutine_threadsafe(self._setup(nats_url), self._loop)
+        try:
+            fut.result(timeout=3)
+        except TimeoutError:
+            raise Exception(f"NATSProducer init, connecting to {ENV_KEY_NATS_URL}: timeout")
+        
+        atexit.register(self._shutdown)
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+        
+    async def _setup(self, nats_url: str):
+        self._nc = NATS()
+        await self._nc.connect(servers=[nats_url])
+        self._js = self._nc.jetstream()
+        # Ensure the stream exists
+        try:
+            await self._js.add_stream(
+                StreamConfig(name=NATS_STREAM_NAME, subjects=[NATS_SUBJECT_LAYOUT_TASKS])
+            )
+        except Exception: # TODO: silently fails if jetstream is disabled, check for Exception type
+            pass
+
+    async def _publish(self, subject: str, message: bytes, headers: dict):
+        ack = await self._js.publish(subject=subject, payload=message, headers=headers)
+        return str(ack.seq)
+    
+    @staticmethod  # TODO: who owns queue transport config?
+    def _to_message(payload: GenerateLayoutRequest) -> bytes:
+        return payload.model_dump_json().encode("utf-8")
+    
+    def _shutdown(self):
+        # Step 1: Close the NATS client
+        future = asyncio.run_coroutine_threadsafe(self._close_client(), self._loop)
+        try:
+            future.result(timeout=3)
+        except Exception as e:
+            print(f"NATS close failed: {e}")
+
+        # Step 2: Stop and close the event loop
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop.run_forever()  # allow all callbacks to complete
+
+        self._loop.close()
+
+    async def _close_client(self):
+        await self._nc.close()
+        

--- a/layout_generator/types.py
+++ b/layout_generator/types.py
@@ -1,0 +1,116 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class _Door(BaseModel):
+    width: int
+    wall: Literal[0, 1, 2, 3]
+    x_center: int
+    open_direction: Literal["inside_left", "inside_right", "outside_left", "outside_right"]
+
+
+class _Window(BaseModel):
+    width: int
+    height: int
+    wall: Literal[0, 1, 2, 3]
+    x_center: int
+
+
+class _Balcony(BaseModel):
+    width: int
+    wall: Literal[0, 1, 2, 3]
+    x_center: int
+
+
+class _RoomDescription(BaseModel):
+    type_id: str
+    length: int
+    width: int
+    doors: list[_Door]
+    windows: list[_Window]
+    balconies: list[_Balcony]
+
+
+class GenerateLayoutRequest(BaseModel):
+    """Describes the input format for the generate_layout method.
+
+    Example:
+    ```
+    {
+        "room_description": {
+            "type_id": "bedroom",
+            "length": 100,
+            "width": 200,
+            "doors": [
+                {
+                    "width": 10,
+                    "wall": 0,
+                    "x_center": 50,
+                    "open_direction": "inside_left"
+                }
+            ],
+            "windows": [
+                {
+                    "width": 10,
+                    "height": 10,
+                    "wall": 2,
+                    "x_center": 2
+                }
+            ],
+            "balconies": [
+                {
+                    "width": 20,
+                    "wall": 2,
+                    "x_center": 2
+                }
+            ]
+        },
+        "furniture_item_ids": ["bed_01", "desk_02", "chair_03"]
+    }
+    ```
+    """
+    room_description: _RoomDescription
+    furniture_item_ids: list[str]
+
+
+TaskStatus = Literal["PENDING", "IN_PROGRESS", "FAILURE", "SUCCESS"]
+
+
+class _FurniturePlacement(BaseModel):
+    furniture_item_id: str
+    x_center: int
+    y_center: int
+    rotation_degree: int
+
+
+class GenerateLayoutResult(BaseModel):
+    """
+    Describes the output format for the get_task_results method.
+
+    Example::
+
+        {
+            "id": "task_123",
+            "furniture_placements": [
+                {
+                    "furniture_item_id": "bed_01",
+                    "x_center": 2,
+                    "y_center": 3,
+                    "rotation_degree": 90
+                },
+                {
+                    "furniture_item_id": "desk_02",
+                    "x_center": 4,
+                    "y_center": 1,
+                    "rotation_degree": 0
+                }
+            ]
+        }
+    """
+
+    id: str
+    furniture_placements: list[_FurniturePlacement]
+
+
+# TODO: add ErrorCodes enum

--- a/nats-demo.compose.yaml
+++ b/nats-demo.compose.yaml
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------
+# A small demo compose file to run nats with jetstream and 
+# localhost port bindings. 
+#
+# Usage:
+#   docker compose -f nats-demo.compose.yaml up
+# -------------------------------------------------------------------
+
+
+
+version: "3.5"
+services:
+  nats:
+    image: nats
+    ports:
+      - "8222:8222"
+      - "4222:4222"
+      - "6222:6222"
+    command: "--jetstream --http_port 8222"

--- a/project/services/layout_generator/service.py
+++ b/project/services/layout_generator/service.py
@@ -1,0 +1,44 @@
+"""
+Service interface for submitting layout generation tasks and retrieving their status and results.
+
+
+Provides the following functions:
+    - create_task: Submit a layout generation request.
+    - get_task_status: Check the current status of a task.
+    - get_task_results: Retrieve the result of a completed task.
+"""
+
+
+from layout_generator.queue.producer.interface import get_task_queue
+from layout_generator.types import GenerateLayoutRequest, GenerateLayoutResult, TaskStatus
+
+
+def create_task(room_description: GenerateLayoutRequest) -> str:
+    """
+    Creates and enqueues a layout generation task using the given room description.
+    Returns a unique task ID.
+    """
+    
+    q = get_task_queue()
+    return q.enqueue_task(payload=room_description)
+
+
+def get_task_status(task_id: str) -> TaskStatus | None:
+    """
+    Checks the status of a layout generation task.
+    Returns the current task status or None if not found.
+    """ 
+
+    q = get_task_queue()
+    return q.get_task_status(task_id)
+
+
+def get_task_results(task_id: str) -> GenerateLayoutResult | None:
+    """
+    Retrieves the result of a completed layout generation task.
+    Returns either the layout result or None if task is not successfully completed 
+    or doesn't exist.
+    """
+
+    q = get_task_queue()
+    return q.get_task_results(task_id)


### PR DESCRIPTION
Попробовал описать своё состояние мысли в коде.
Основные идеи:
1. Появляется новый элемент в технологическом стеке: брокер сообщений NATS. 
Он супер легкий (размер образа 17Мб), идёт одним бинарником. Можно будет еще поисследовать, как он масштабируется, но на минимальных нагрузках он будет незаметен совершенно.
Из полезных фичей:
 - Поддерживает exactly-once гарантии доставки сообщений (для тяжелых вычислений как раз то, что нужно), но кушает для этого немного жесткого диска. 
 - Предоставляет промежуточное хранилище для сериализованных планировок.
 - Какое-то observability идёт в комплекте, как минимум наружу торчат  http ручки с метриками.
 - Официальные клиентские библиотеки для кучи языков, включая питон (правда, там только асинхронные методы, пришлось их пока что закопать в отдельный eventloop.
2. Вокруг очереди сообщений есть интерфейс TaskQueue, который принимает на вход питоновские модели. Модели сейчас описаны через pydantic, но тут возможны варианты. Можно передавать словари, можно передавать вообще сырой json. На другом конце всё это в любом случае еще раз десериализуется и валидируется. Вопрос только в том, когда мы хотим получить ошибки валидации.
3. В новом django приложении project, которое пока живёт вот тут: #159, появляется сервис-обёртка вокруг TaskQueue. Идея этого сервиса: дать полный набор функций, необходимых для взаимодействия с очередью задач.

P.S. Принимаются замечания по стилю кода (названия переменных, функций, структура папок и т.д. и т.п.).
Главная цель -- сделать так, чтобы код был понятен и поддерживаем всеми участниками команды, так что я открыт к предложениям на эту тему
